### PR TITLE
Adds global typedef for SortableEvent

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ You can use the options' `onUpdate` method to track the changes (see also *Passi
 ```ts
 constructor() {
   this.options = {
-    onUpdate: (event: any) => {
+    onUpdate: (event: SortableEvent) => {
       this.postChangesToServer();
     }
   };

--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,4 @@
 export * from './src/sortablejs-options';
 export * from './src/sortablejs.directive';
 export * from './src/sortablejs.module';
+export * from './src/sortable-event';

--- a/src/sortable-event.ts
+++ b/src/sortable-event.ts
@@ -1,0 +1,6 @@
+export interface SortableEvent extends Event {
+    oldIndex: number;
+    newIndex: number;
+    item: HTMLElement;
+    clone: HTMLElement
+}

--- a/src/sortablejs-options.ts
+++ b/src/sortablejs-options.ts
@@ -1,3 +1,5 @@
+import { SortableEvent } from './sortable-event';
+
 export interface SortablejsOptions {
   group?: string | {
     name?: string;
@@ -31,12 +33,12 @@ export interface SortablejsOptions {
   fallbackTolerance?: number;
   setData?: (dataTransfer: any, draggedElement: any) => any;
   onStart?: (event: any) => any;
-  onEnd?: (event: any) => any;
-  onAdd?: (event: any) => any;
-  onAddOriginal?: (event: any) => any;
-  onUpdate?: (event: any) => any;
-  onSort?: (event: any) => any;
-  onRemove?: (event: any) => any;
+  onEnd?: (event: SortableEvent) => any;
+  onAdd?: (event: SortableEvent) => any;
+  onAddOriginal?: (event: SortableEvent) => any;
+  onUpdate?: (event: SortableEvent) => any;
+  onSort?: (event: SortableEvent) => any;
+  onRemove?: (event: SortableEvent) => any;
   onFilter?: (event: any) => any;
   onMove?: (event: any) => boolean;
   scrollFn?: (offsetX: any, offsetY: any, originalEvent: any) => any;

--- a/src/sortablejs.directive.ts
+++ b/src/sortablejs.directive.ts
@@ -4,6 +4,7 @@ import { SortablejsBindingTarget } from './sortablejs-binding-target';
 import { SortablejsBindings } from './sortablejs-bindings';
 import { SortablejsOptions } from './sortablejs-options';
 import { SortablejsService } from './sortablejs.service';
+import { SortableEvent } from './sortable-event';
 
 const OriginalSortable: any = require('sortablejs');
 
@@ -148,4 +149,3 @@ export class SortablejsDirective implements OnInit, OnChanges, OnDestroy {
 
 }
 
-interface SortableEvent { oldIndex: number; newIndex: number; item: HTMLElement; clone: HTMLElement }


### PR DESCRIPTION
There already was an interface for `SortableEvent`. 
This change will makes it available for depending packages to use the interface to enable more strict type checking.

Adds SortableEvent interface and assigns for methods in SortablejsOptions:
- onEnd
- onAdd
- onAddOriginal
- onUpdate
- onSort
- onRemove