### PR TITLE
Change 'SortablejsOptions' to 'Options' in examples code since the previous one is deprecated 

### DIFF
--- a/src/app/examples/multiple-lists/multiple-lists.component.ts
+++ b/src/app/examples/multiple-lists/multiple-lists.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { SortablejsOptions } from 'ngx-sortablejs';
+import { Options } from 'sortablejs';
 
 @Component({
   selector: 'app-multiple-lists',
@@ -25,7 +25,7 @@ export class MultipleListsComponent {
     '10',
   ];
 
-  normalOptions: SortablejsOptions = {
+  normalOptions: Options = {
     group: 'normal-group',
   };
 
@@ -47,7 +47,7 @@ export class MultipleListsComponent {
     '10',
   ];
 
-  clone1Options: SortablejsOptions = {
+  clone1Options: Options = {
     group: {
       name: 'clone-group',
       pull: 'clone',
@@ -55,7 +55,7 @@ export class MultipleListsComponent {
     },
   };
 
-  clone2Options: SortablejsOptions = {
+  clone2Options: Options = {
     group: 'clone-group',
   };
 
@@ -85,21 +85,21 @@ export class MultipleListsComponent {
     '13',
   ];
 
-  list1Options: SortablejsOptions = {
+  list1Options: Options = {
     group: {
       name: 'group1',
       put: false,
     },
   };
 
-  list2Options: SortablejsOptions = {
+  list2Options: Options = {
     group: {
       name: 'group2',
       put: ['group1', 'group2'],
     },
   };
 
-  list3Options: SortablejsOptions = {
+  list3Options: Options = {
     group: {
       name: 'group2',
       pull: 'clone',
@@ -108,7 +108,7 @@ export class MultipleListsComponent {
     },
   };
 
-  list4Options: SortablejsOptions = {
+  list4Options: Options = {
     group: {
       name: 'group2',
       put: ['group1'],

--- a/src/app/examples/sortable-with-options/sortable-with-options.component.ts
+++ b/src/app/examples/sortable-with-options/sortable-with-options.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { SortablejsOptions } from 'ngx-sortablejs';
+import { Options } from 'sortablejs';
 
 @Component({
   selector: 'app-sortable-with-options',
@@ -28,15 +28,15 @@ export class SortableWithOptionsComponent {
 
   scrollableItems = Array.from({ length: 30 }).map((u, i) => i + 1);
 
-  draggableOptions: SortablejsOptions = {
+  draggableOptions: Options = {
     draggable: '.draggable',
   };
 
-  eventOptions: SortablejsOptions = {
+  eventOptions: Options = {
     onUpdate: () => this.eventUpdateCounter++,
   };
 
-  scrollableOptions: SortablejsOptions = {
+  scrollableOptions: Options = {
     scroll: true,
     scrollSensitivity: 100,
   };


### PR DESCRIPTION
1. Changed the import of interface 'Options' according to the newer module 'sortablejs' instead of 'ngx-sortablejs' .
2. Replaced 'SortablejsOptions' with 'Options' throughout the code. 