### PR TITLE
Fix deprecated ModuleWithProviders

### DIFF
--- a/projects/ngx-sortablejs/src/lib/sortablejs.module.ts
+++ b/projects/ngx-sortablejs/src/lib/sortablejs.module.ts
@@ -9,7 +9,7 @@ import { SortablejsDirective } from './sortablejs.directive';
 })
 export class SortablejsModule {
 
-  public static forRoot(globalOptions: SortablejsOptions): ModuleWithProviders {
+  public static forRoot(globalOptions: SortablejsOptions): ModuleWithProviders<any> {
     return {
       ngModule: SortablejsModule,
       providers: [


### PR DESCRIPTION
https://next.angular.io/guide/migration-module-with-providers

Angular version 9 deprecates use of ModuleWithProviders without an explicitly generic type, where the generic type refers to the type of the NgModule.